### PR TITLE
[@now/php] Add config option for included files

### DIFF
--- a/packages/now-php/index.js
+++ b/packages/now-php/index.js
@@ -6,20 +6,18 @@ const path = require('path');
 const rename = require('@now/build-utils/fs/rename.js');
 
 exports.config = {
-  maxLambdaSize: '10mb'
+  maxLambdaSize: '10mb',
 };
 
 exports.build = async ({ files, entrypoint, config }) => {
   // Fetch the included files config, or default (**)
   const includedFilesGlob = (config ? config.include : false) || '**';
+  let includedFiles = files;
   if (includedFilesGlob !== '**') {
     // Download the files to run a glob against them
     const tmpDir = getWritableDir();
     await download(files, tmpDir);
-    const includedFiles = await glob(includedFilesGlob, tmpDir);
-  } else {
-    // No need to download them
-    const includedFiles = files;
+    includedFiles = await glob(includedFilesGlob, tmpDir);
   }
   // move all user code to 'user' subdirectory
   const userFiles = rename(includedFiles, name => path.join('user', name));

--- a/packages/now-php/index.js
+++ b/packages/now-php/index.js
@@ -1,5 +1,7 @@
 const { createLambda } = require('@now/build-utils/lambda.js');
 const glob = require('@now/build-utils/fs/glob.js');
+const download = require('@now/build-utils/fs/download.js');
+const getWritableDir = require('@now/build-utils/fs/get-writable-directory.js');
 const path = require('path');
 const rename = require('@now/build-utils/fs/rename.js');
 
@@ -7,9 +9,20 @@ exports.config = {
   maxLambdaSize: '10mb'
 };
 
-exports.build = async ({ files, entrypoint }) => {
+exports.build = async ({ files, entrypoint, config }) => {
+  // Fetch the included files config, or default (**)
+  const includedFilesGlob = (config ? config.include : false) || '**';
+  if (includedFilesGlob !== '**') {
+    // Download the files to run a glob against them
+    const tmpDir = getWritableDir();
+    await download(files, tmpDir);
+    const includedFiles = await glob(includedFilesGlob, tmpDir);
+  } else {
+    // No need to download them
+    const includedFiles = files;
+  }
   // move all user code to 'user' subdirectory
-  const userFiles = rename(files, name => path.join('user', name));
+  const userFiles = rename(includedFiles, name => path.join('user', name));
   const launcherFiles = await glob('**', path.join(__dirname, 'dist'));
   const zipFiles = { ...userFiles, ...launcherFiles };
 


### PR DESCRIPTION
This config option can select the files included into the php build. This can be used by including the next build line into `now.json`
```
{ "src": "*.php", "use": "@now/php", "config": { "include": "*.php" } },
``